### PR TITLE
Implementing Generalized Gamma Distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Example/
 *.csv
 *.pkl
 .ipynb_checkpoints/
+.DS_Store

--- a/kalkayotl/Models.py
+++ b/kalkayotl/Models.py
@@ -7,7 +7,7 @@ import theano
 from theano import tensor as tt, printing
 
 from kalkayotl.Transformations import Iden,pc2mas,cartesianToSpherical,phaseSpaceToAstrometry,phaseSpaceToAstrometry_and_RV
-from kalkayotl.Priors import EDSD,EFF,King
+from kalkayotl.Priors import EDSD,GGD,EFF,King
 
 ################################## Model 1D ####################################
 class Model1D(Model):
@@ -134,10 +134,14 @@ class Model1D(Model):
 				King("offset",location=0.0,scale=1.0,rt=self.rt,shape=self.N)
 				pm.Deterministic("source",self.loc + self.scl*self.offset)
 			
-		#---------- Galactic oriented prior ---------------------------------------------
+		#---------- Galactic oriented priors ---------------------------------------------
 		elif prior is "EDSD":
 			EDSD("source",scale=self.scl,shape=self.N)
-		
+		elif prior is "GGD":
+			alpha = pm.HalfFlat('alpha',testval=1.0)
+			betap1 = pm.HalfFlat('beta_plus_1', testval=2.0)
+			beta = pm.Deterministic('beta', betap1-1.0)
+			GGD("source",scale=self.scl,alpha=alpha,beta=beta,shape=self.N)
 		else:
 			sys.exit("The specified prior is not implemented")
 		#-----------------------------------------------------------------------------

--- a/kalkayotl/Priors.py
+++ b/kalkayotl/Priors.py
@@ -5,6 +5,7 @@ This file contains the non-standard prior
 
 import numpy as np
 import theano.tensor as tt
+from theano.ifelse import ifelse
 
 from pymc3.util import get_variable_name
 from pymc3.distributions.dist_math import bound
@@ -148,6 +149,160 @@ class EDSD(PositiveContinuous):
 		result = 1.0 - tt.exp(-value/scale)*(value**2 + 2. * value * scale + 2. * scale**2)/(2.*scale**2)
 		return result
 ################################################################################################################
+
+##################################### GGD #######################################################
+# Implemented by Trevor DW
+#=============== GDD generator ===============================
+class ggd_gen(rv_continuous):
+	"GGD distribution"
+	def _pdf(self, x,L,alpha,beta):
+		fac1 = 1.0 / gamma((beta+1.0)/alpha)
+		fac2 = alpha / np.power(L, beta+1.0)
+		fac3 = np.power(r, beta)
+		fac4 = np.exp(-np.power(r/L, alpha))
+		return fac1*fac2*fac3*fac4
+
+	def _cdf(self, x,L,alpha,beta):
+		result = gammainc((beta+1.0)/alpha,np.power(r/L,alpha))
+		return result
+
+	def _rvs(self,L,alpha,beta):
+		sz, rndm = self._size, self._random_state
+		u = rndm.random_sample(size=sz)
+
+		v = np.zeros_like(u)
+
+		for i in range(sz[0]):
+
+			sol = root_scalar(lambda x : self._cdf(x,L,alpha,beta) - u[i],
+				bracket=[0,1.e10],
+				method='brentq')
+			v[i] = sol.root
+		return v
+
+
+
+#ggd = ggd_gen(name='ggd') TODO: Make an object for testing
+#===============================================================
+
+
+class GGD(PositiveContinuous):
+	R"""
+	Generalized Gamma Distribution, PDF looks like
+	.. math::
+	   GGD(x \mid L, \alpha, \beta) =
+                   \frac{1}{\Gamma(\frac{\beta+1}{\alpha})}
+                   \frac{\alpha}{L^{\beta+1}}
+		   x^\beta}
+		   \exp\left(-(\frac{x}{L})^\beta\right)
+
+	.. note::
+	   See Bailer-Jones et al. (2021) for details.
+	   
+	========  ==========================================
+	Support   :math:`x \in [0, \infty)`
+	========  ==========================================
+	Parameters
+	----------
+	L : float
+		Scale parameter :math:`L` (``L`` > 0) .
+	alpha : float
+		Additional scale parameter, alpha > 0
+	beta : float
+		Additional scale parameter, beta > -1. The EDSD is a special case of GDD with alpha=1.0, beta=2.0
+
+	Examples
+	--------
+	.. code-block:: python
+		with pm.Model():
+			x = pm.GGD('x', scale=1000, alpha=1.0, beta=2.0)
+	"""
+
+	def __init__(self, scale=None, alpha=None, beta=None, *args, **kwargs):
+
+		super().__init__(*args, **kwargs)
+
+		self.scale = scale = tt.as_tensor_variable(scale)
+		self.alpha = alpha = tt.as_tensor_variable(alpha)
+		self.beta = beta = tt.as_tensor_variable(beta)
+		zero = tt.as_tensor_variable(0.0)
+		self.mode = ifelse(tt.le(beta,zero), tt.as_tensor_variable(zero), self.scale * tt.pow(self.beta/self.alpha, 1.0/self.alpha))
+
+	def random(self, point=None, size=None):
+		"""
+		Draw random values from HalfNormal distribution.
+		Parameters
+		----------
+		point : dict, optional
+			Dict of variable values on which random values are to be
+			conditioned (uses default point if not specified).
+		size : int, optional
+			Desired size of random sample (returns one sample if not
+			specified).
+		Returns
+		-------
+		array
+		"""
+		scale, alpha, beta = draw_values([self.scale, self.alpha, self.beta], point=point)[0]
+		return generate_samples(ggd.rvs, L=scale, alpha=alpha, beta=beta,
+								dist_shape=self.shape,
+								size=size)
+
+	def logp(self, value):
+		"""
+		Calculate log-probability of GDD distribution at specified value.
+		Parameters
+		----------
+		value : numeric
+			Value(s) for which log-probability is calculated. If the log probabilities for multiple
+			values are desired the values must be provided in a numpy array or theano tensor
+		Returns
+		-------
+		TensorVariable
+		"""
+		L  = self.scale
+		alpha = self.alpha
+		beta = self.beta
+		fac1 = -tt.log(tt.gamma((beta+1.0)/alpha))
+		fac2 = tt.log(alpha)
+		fac3 = -(beta+1.0)*tt.log(L)
+		fac4 = beta*tt.log(value)
+		fac5 = -tt.power(value/L, alpha)
+		log_d =  fac1 + fac2 + fac3 + fac4 + fac5
+		return log_d
+
+	def _repr_latex_(self, name=None, dist=None):
+		if dist is None:
+			dist = self
+		scale = dist.scale
+		alpha = dist.alpha
+		beta = dist.beta
+		name = r'\text{%s}' % name
+		return r'${} \sim \text{{GGD}}(\mathit{{scale}}={},\mathit{{alpha}}={},\mathit{{beta}}={})$'.format(name,
+																		 get_variable_name(scale),get_variable_name(alpha),get_variable_name(beta))
+
+	def logcdf(self, value):
+		"""
+		Compute the log of the cumulative distribution function for GGD distribution
+		at the specified value.
+		Parameters
+		----------
+		value: numeric
+			Value(s) for which log CDF is calculated. If the log CDF for multiple
+			values are desired the values must be provided in a numpy array or theano tensor.
+		Returns
+		-------
+		TensorVariable
+		"""
+		scale  = self.scale
+		alpha = self.alpha
+		beta = self.beta
+		result = tt.log(gammainc((beta+1.0)/alpha,tt.pow(r/L,alpha)))
+		return result
+################################################################################################################
+
+
+
 
 ##################################### EFF #######################################################
 #=============== EFF generator ===============================

--- a/kalkayotl/Priors.py
+++ b/kalkayotl/Priors.py
@@ -225,7 +225,7 @@ class GGD(PositiveContinuous):
 		self.scale = scale = tt.as_tensor_variable(scale)
 		self.alpha = alpha = tt.as_tensor_variable(alpha)
 		self.beta = beta = tt.as_tensor_variable(beta)
-		zero = tt.as_tensor_variable(0.0)
+		zero = tt.as_tensor_variable(np.float64(0.0))
 		self.mode = ifelse(tt.le(beta,zero), zero, self.scale * tt.pow(self.beta/self.alpha, 1.0/self.alpha))
 
 	def random(self, point=None, size=None):

--- a/kalkayotl/Priors.py
+++ b/kalkayotl/Priors.py
@@ -226,7 +226,7 @@ class GGD(PositiveContinuous):
 		self.alpha = alpha = tt.as_tensor_variable(alpha)
 		self.beta = beta = tt.as_tensor_variable(beta)
 		zero = tt.as_tensor_variable(0.0)
-		self.mode = ifelse(tt.le(beta,zero), tt.as_tensor_variable(zero), self.scale * tt.pow(self.beta/self.alpha, 1.0/self.alpha))
+		self.mode = ifelse(tt.le(beta,zero), zero, self.scale * tt.pow(self.beta/self.alpha, 1.0/self.alpha))
 
 	def random(self, point=None, size=None):
 		"""


### PR DESCRIPTION
Here's a first hack at implementing a Generalized Gamma Distribution. I've only modified Priors.py and Models.py. If you approve of what I've done @olivares-j, I can start seeing how the new code does in the inference & evidence modules.

A couple small details:

- The GGD has three parameters: a length scale L, a rate parameter alpha and a shape parameter beta (EDSD is special case with alpha=1, beta=2). I'm assuming these are free parameters, where L is set using `self.scl` (`hyper_beta`, gamma distributed), and alpha/beta are uniformly distributed, subject to alpha > 0, beta > -1. I have no idea whether or not these are sensible choices. I'd like to keep some of these parameters free for the evidence computation.
- The GGD CDF uses the lower incomplete gamma function (`scipy.special.gammainc`), which doesn't seem to have an equivalent in `theano.tensor`. This might be an issue in the `logcdf` method? 

Feel free to check out the code; hopefully it's not too broken. Let me know what you think!