### PR TITLE
Fixes GGD implementation to work with the Inference/Evidence modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Example/
 *.pkl
 .ipynb_checkpoints/
 .DS_Store
+trevor_testing

--- a/kalkayotl/Evidence.py
+++ b/kalkayotl/Evidence.py
@@ -73,8 +73,8 @@ class Evidence1D():
 
 		#================ Hyper-prior =====================================
 		if prior is "GGD": 
-			hp_alpha = st.uniform(loc=0.0,scale=1e10) #alpha > 0
-			hp_beta = st.uniform(loc=-1.0,scale=1e10) #beta > -1
+			hp_alpha = st.uniform(loc=0.0,scale=100) #alpha > 0
+			hp_beta = st.uniform(loc=-1.0,scale=100) #beta > -1
 		else:
 			hp_loc = st.norm(loc=hyper_alpha[0],scale=hyper_alpha[1])
 		hp_scl = st.gamma(a=2.0,scale=hyper_beta[0]/2.0)

--- a/kalkayotl/Evidence.py
+++ b/kalkayotl/Evidence.py
@@ -72,7 +72,12 @@ class Evidence1D():
 
 
 		#================ Hyper-prior =====================================
-		hp_loc = st.norm(loc=hyper_alpha[0],scale=hyper_alpha[1])
+		if prior is "GGD": # We need a big wide uniform distribution; GGD has no loc
+			hp_loc = st.uniform(loc=0.0,scale=1e10) 
+			hp_alpha = st.uniform(loc=0.0,scale=1e10) #alpha > 0
+			hp_beta = st.uniform(loc=-1.0,scale=1e10) #beta > -1
+		else:
+			hp_loc = st.norm(loc=hyper_alpha[0],scale=hyper_alpha[1])
 		hp_scl = st.gamma(a=2.0,scale=hyper_beta[0]/2.0)
 		#========================================================================
 
@@ -241,7 +246,24 @@ class Evidence1D():
 					x[0] = hp_loc.ppf(u[0])
 					x[1] = hp_scl.ppf(u[1])
 					return x
+                
+		elif prior is "GGD":
+			self.D = 3
+			self.names = ["scl","alpha","beta"]
 
+			def prior_sample(theta):
+				a = (theta[2] + 1)/theta[1] #beta+1/alpha
+				c = theta[1]               
+				result = st.gengamma.rvs(a=a,c=c,scale=theta[0],loc=0.0,size=self.M)
+				return result
+
+			def hp_transform(u):
+				x = np.zeros_like(u)
+				x[0] = hp_scl.ppf(u[0])
+				x[1] = hp_alpha.ppf(u[1])
+				x[2] = hp_beta.ppf(u[1])
+				return x
+            
 		else:
 			sys.exit("The specified prior is not supported. Check spelling.")
 

--- a/kalkayotl/Evidence.py
+++ b/kalkayotl/Evidence.py
@@ -72,8 +72,7 @@ class Evidence1D():
 
 
 		#================ Hyper-prior =====================================
-		if prior is "GGD": # We need a big wide uniform distribution; GGD has no loc
-			hp_loc = st.uniform(loc=0.0,scale=1e10) 
+		if prior is "GGD": 
 			hp_alpha = st.uniform(loc=0.0,scale=1e10) #alpha > 0
 			hp_beta = st.uniform(loc=-1.0,scale=1e10) #beta > -1
 		else:

--- a/kalkayotl/Models.py
+++ b/kalkayotl/Models.py
@@ -58,9 +58,10 @@ class Model1D(Model):
 			shape = len(hyper_delta)
 
 		#------------------------ Location ----------------------------------
-		if parameters["location"] is None:
+		if (parameters["location"] is None) & (prior is not "GGD"):
 			pm.Normal("loc",mu=hyper_alpha[0],sigma=hyper_alpha[1],shape=shape)
-
+		elif prior is "GGD": # ignore loc for GGD
+            continue
 		else:
 			self.loc = parameters["location"]
 

--- a/kalkayotl/Models.py
+++ b/kalkayotl/Models.py
@@ -139,9 +139,8 @@ class Model1D(Model):
 		elif prior is "EDSD":
 			EDSD("source",scale=self.scl,shape=self.N)
 		elif prior is "GGD":
-			alpha = pm.HalfFlat('alpha',testval=1.0)
-			betap1 = pm.HalfFlat('beta_plus_1', testval=2.0)
-			beta = pm.Deterministic('beta', betap1-1.0)
+			alpha = pm.Uniform('alpha',lower=0, upper=100, testval=1.0)
+			beta = pm.Uniform('beta', lower=-1, upper=99, testval=2.0)
 			GGD("source",scale=self.scl,alpha=alpha,beta=beta,shape=self.N)
 		else:
 			sys.exit("The specified prior is not implemented")

--- a/kalkayotl/Models.py
+++ b/kalkayotl/Models.py
@@ -61,7 +61,7 @@ class Model1D(Model):
 		if (parameters["location"] is None) & (prior is not "GGD"):
 			pm.Normal("loc",mu=hyper_alpha[0],sigma=hyper_alpha[1],shape=shape)
 		elif prior is "GGD": # ignore loc for GGD
-            continue
+			pass
 		else:
 			self.loc = parameters["location"]
 

--- a/kalkayotl/inference.py
+++ b/kalkayotl/inference.py
@@ -272,6 +272,7 @@ class Inference:
 		print("Configuring "+self.prior+" prior")
 
 		if (self.parameters["location"] is None)&(self.prior is not 'GGD'):
+			print(self.prior)
 			assert self.hyper_alpha is not None, "hyper_alpha must be specified."
 
 		if self.parameters["scale"] is None:

--- a/kalkayotl/inference.py
+++ b/kalkayotl/inference.py
@@ -129,6 +129,8 @@ class Inference:
 
 		if prior is "Gaussian":
 			assert hyper_delta is None, "Parameter hyper_delta is only valid for GMM prior."
+		if prior is "GGD":
+			assert (hyper_alpha is None)&(hyper_gamma is None)&(hyper_delta is None), "GGD prior only needs hyper_beta parameter."
 
 
 	def load_data(self,file_data,id_name='source_id',radec_inflation=10.0,id_length=10,corr_func="Lindegren+2020",*args,**kwargs):
@@ -269,7 +271,7 @@ class Inference:
 
 		print("Configuring "+self.prior+" prior")
 
-		if self.parameters["location"] is None:
+		if (self.parameters["location"] is None)&(self.prior is not 'GGD'):
 			assert self.hyper_alpha is not None, "hyper_alpha must be specified."
 
 		if self.parameters["scale"] is None:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Kalkayotl',
-    version='1.1',
+    version='1.1.1',
     author='Javier Olivares',
     author_email='javier.olivares-romero@u-bordeaux.fr',
     packages=['kalkayotl'],


### PR DESCRIPTION
To do inference with the GGD, one needs to supply only `hyper_beta`, all other parameters & hyper-parameters should be None. `kalkayotl` should throw an error if that isn't the case. 

I've tested the implementation on a set of 500 Gaia stars within 1 degree of (l,b)=(180,45) given by 
```sql
SELECT TOP 500 gaia.*
FROM gaiadr3.gaia_source_lite AS gaia
WHERE DISTANCE(180.0, 45.0, gaia.l, gaia.b) < 1
```
and the `example.py` script successfully runs. I'm attaching the [results](https://github.com/olivares-j/Kalkayotl/files/10771999/top500_galactic_180_45_1deg-result.csv) of that query; I've added columns from the full DR3 database and the EDR3 geometric distance catalog as well. 

TODO:
- ~Make sure the outputs make sense~
- ~Compare with Bailer-Jones+(2021) distances; same prior, so we should get similar results.~ Done, here's a comparison [plot](https://github.com/olivares-j/Kalkayotl/files/10865218/distance_compare.pdf)
- ~Determine whether our choices of prior for the length scale, alpha, and beta are suitable.~ Choices of prior seem to yield ok results when testing, but getting `hyper_beta` right for the GGD is important for convergence; users should first attempt to fit a histogram with a GGD to get a good guess.

Feel free to check out the code and verify that it works as you might expect before merging. 